### PR TITLE
Fixed CLIENT_OPTIONS typo

### DIFF
--- a/CLIENT_OPTIONS.md
+++ b/CLIENT_OPTIONS.md
@@ -555,7 +555,7 @@ maxAuraLevel = 0
 fogChunkDistanceOverride = null
 
 /**
- * RGB string for fog colour override. e.g. #ffffff
+ * HEX string for fog colour override. e.g. #ffffff
  * @type {string}
  */
 fogColourOverride = null


### PR DESCRIPTION
Fixed the typo that claimed RGB values to be HEX values. I have tested with HEX and RGB strings and only HEX strings work.